### PR TITLE
fix: fix legacy auth issue when htpasswd plugin is defined after openid

### DIFF
--- a/src/server/plugin/AuthCore.ts
+++ b/src/server/plugin/AuthCore.ts
@@ -7,7 +7,14 @@ import { ERRORS } from "@/server/constants";
 import { debug } from "@/server/debugger";
 
 import type { AuthProvider, OpenIDToken } from "./AuthProvider";
-import { base64Decode, base64Encode, getAllConfiguredGroups, getAuthenticatedGroups, isNowBefore } from "./utils";
+import {
+  base64Decode,
+  base64Encode,
+  getAllConfiguredGroups,
+  getAuthenticatedGroups,
+  isJWT,
+  isNowBefore,
+} from "./utils";
 
 interface UserPayload {
   sub?: string;
@@ -206,8 +213,12 @@ export class AuthCore {
       }
 
       return { name, real_groups: realGroups };
-    } else {
+    } else if (isJWT(token)) {
+      debug("verifying npm token using jwt");
       return this.verifyJWT(token);
+    } else {
+      debug("npm token is not a valid jwt");
+      throw new TypeError(ERRORS.INVALID_TOKEN);
     }
   }
 

--- a/src/server/plugin/Plugin.ts
+++ b/src/server/plugin/Plugin.ts
@@ -123,7 +123,7 @@ export class Plugin
     try {
       user = await this.core.verifyNpmToken(token);
     } catch (e: any) {
-      debug(`%s. user: "%s", token: "%s"`, e.message, username, token);
+      debug(`%s. user: "%s", token: "%s", falling back to legacy auth`, e.message, username, token);
 
       // the token is not valid by us, let the next auth plugin to handle it
       callback(null, false);

--- a/src/server/plugin/utils.ts
+++ b/src/server/plugin/utils.ts
@@ -113,3 +113,14 @@ export function getBaseUrl(urlPrefix: string, req: Request, noTrailingSlash = fa
 
   return noTrailingSlash ? base.replace(/\/$/, "") : base;
 }
+
+/**
+ * Check if the token is a JWT
+ *
+ * @param token The token to check.
+ * @returns {boolean} True if the token is a JWT token, false otherwise.
+ */
+export function isJWT(token: string): boolean {
+  // A JWT token typically has three parts separated by dots
+  return typeof token === "string" && token.split(".").length === 3;
+}


### PR DESCRIPTION
Check if the token is a valid jwt string before we do jwt verify.
fix #15