### PR TITLE
feat(store): add DynamoDB backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Now you can use the openid-connect auth in the webUI.
 | <details><summary>username-claim</summary>The claim to get the username from the ID token or userinfo endpoint response</details>                                                | string                           | `sub`                       | No       | `name`                                                 |
 | <details><summary>groups-claim</summary>The claim to get the groups from the ID token or userinfo endpoint response</details>                                                    | string                           |                             | No       | `groups`                                               |
 | <details><summary>provider-type</summary>The provider type to get groups from the provider. Supported values: `gitlab`</details>                                                 | string                           |                             | No       | `gitlab`                                               |
-| <details><summary>store-type</summary>The store type to store the OIDC state and caches.</details>                                                                               | "in-memory" \| "redis" \| "file" | `in-memory`                 | No       | `file`                                                 |
+| <details><summary>store-type</summary>The store type to store the OIDC state and caches.</details>                                                                               | "in-memory" \| "redis" \| "file" \| "dynamodb" | `in-memory`                 | No       | `file`                                                 |
 | <details><summary>store-config</summary>The store configuration.</details>                                                                                                       | string \| object                 | `{ ttl: 60000 }`            | No       | `./store`                                              |
 | <details><summary>keep-passwd-login</summary>Keep the htpasswd login dialog. If set to `true`, the htpasswd login dialog will be kept.</details>                                 | boolean                          | `undefined`                 | No       | `true`                                                 |
 | <details><summary>login-button-text</summary>The text of the OpenID connect login button</details>                                                                               | string                           | `Login with OpenID Connect` | No       | `Login with GitLab`                                    |
@@ -196,6 +196,49 @@ auth:
     store-config:
       ttl: 60000
       dir: ./store
+```
+
+4. dynamodb
+
+When using the `dynamodb` store, OIDC state, user info, groups and webauthn tokens are persisted in an AWS DynamoDB table — shared across all replicas of the verdaccio process so a request can resolve a session created by any other replica.
+
+| Config key   | Description                                                                                                                                 | Value Type       | Default  | Required | Example                                |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- | -------- | -------- | -------------------------------------- |
+| ttl          | The TTL of the OIDC state (ms).                                                                                                             | number \| string | `60000`  | No       | `1m`                                   |
+| tableName    | DynamoDB table name. The table must already exist with `pk` (S) hash key, `sk` (S) range key, and `expires` configured as TTL attribute.    | string           |          | Yes      | `verdaccio-openid`                     |
+| region       | AWS region of the table.                                                                                                                    | string           |          | Yes      | `us-east-1`                            |
+| partitionKey | Partition-key value used to namespace this plugin's rows. Set a unique value when sharing the table with other writers.                     | string           | `OIDC`   | No       | `OIDC-prod`                            |
+
+Credentials are resolved through the standard AWS SDK provider chain: environment variables (including `AWS_PROFILE` for named profiles), `~/.aws/credentials`, container credentials (EKS Pod Identity / IRSA), etc. No keys are ever read from the verdaccio config.
+
+The IAM principal used by the verdaccio process needs the following actions on the table ARN:
+
+```
+dynamodb:GetItem
+dynamodb:PutItem
+dynamodb:DeleteItem
+```
+
+Config example:
+
+```yaml
+auth:
+  openid:
+    store-type: dynamodb
+    store-config:
+      tableName: verdaccio-openid
+      region: us-east-1
+```
+
+```yaml
+auth:
+  openid:
+    store-type: dynamodb
+    store-config:
+      ttl: 1m
+      tableName: shared-app-state
+      region: us-east-1
+      partitionKey: OIDC-prod
 ```
 
 #### keep-passwd-login

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "picocolors": "^1.1.1",
     "serve-static": "^2.2.1",
     "stable-hash": "^0.0.6",
-    "yup": "^1.7.1"
+    "yup": "^1.7.1",
+    "@aws-sdk/client-dynamodb": "^3.700.0",
+    "@aws-sdk/lib-dynamodb": "^3.700.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3.700.0
+        version: 3.1051.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3.700.0
+        version: 3.1051.0(@aws-sdk/client-dynamodb@3.1051.0)
       '@gitbeaker/rest':
         specifier: ^43.8.0
         version: 43.8.0
@@ -215,6 +221,115 @@ importers:
         version: 4.1.4(@types/node@25.6.0)(jsdom@15.2.1)(vite@8.0.6(@types/node@25.6.0)(terser@5.46.1))
 
 packages:
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-dynamodb@3.1051.0':
+    resolution: {integrity: sha512-HCTEpqErM1yUCgzVSZivqoF5Ha6Qn/flP1bQi+oarzlrhXvULwTPTSLHPrInVgCMpbJLvbGb3+tWLGqL5mHaBw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.12':
+    resolution: {integrity: sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.38':
+    resolution: {integrity: sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.40':
+    resolution: {integrity: sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.42':
+    resolution: {integrity: sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.42':
+    resolution: {integrity: sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.43':
+    resolution: {integrity: sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.38':
+    resolution: {integrity: sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.42':
+    resolution: {integrity: sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    resolution: {integrity: sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/dynamodb-codec@3.973.12':
+    resolution: {integrity: sha512-E+qpJPN1QLzfeVDQe1gVmMiHu9PTJWwXqSQjIt8mH5OQXmds2J/IN+Ar6Oa9ZhhuPZb4fPkcgZg4UEpwJM90NA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/endpoint-cache@3.972.5':
+    resolution: {integrity: sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/lib-dynamodb@3.1051.0':
+    resolution: {integrity: sha512-dtxgjDqeeQdtucyxmKV1z4wjpXdYAtTXM6rDn70lTB6ihpNW3LE+qSehkOaTCID54qFOWYvUNhogUF4Rg7Lwgg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1051.0
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.13':
+    resolution: {integrity: sha512-1r6EkFdSQ4quTP3pW8yWIcYuyDwdwdBxGr+kfuPFYE3DqR+1gBc6NyJneAyoIs+wc/cUfnyJ4ZYC0T2SQTxP9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.10':
+    resolution: {integrity: sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    resolution: {integrity: sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1049.0':
+    resolution: {integrity: sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-dynamodb@3.996.2':
+    resolution: {integrity: sha512-ddpwaZmjBzcApYN7lgtAXjk+u+GO8fiPsxzuc59UqP+zqdxI1gsenPvkyiHiF9LnYnyRGijz6oN2JylnN561qQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-dynamodb': ^3.1003.0
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.24':
+    resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -858,6 +973,9 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nolyfill/abab@1.0.44':
     resolution: {integrity: sha512-ZQFi9RSKHKnXM4lLtazYx7otLcqEpQ6sSzs7yzb6zlcimyFIv3CV4s2G+CaA3GnPDTmUFugCn2wWap4jynGQow==}
     engines: {node: '>=12.4.0'}
@@ -949,42 +1067,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.13':
     resolution: {integrity: sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.13':
     resolution: {integrity: sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.13':
     resolution: {integrity: sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.13':
     resolution: {integrity: sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==}
@@ -1131,79 +1243,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1238,6 +1337,42 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@smithy/core@3.24.3':
+    resolution: {integrity: sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.3':
+    resolution: {integrity: sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.3':
+    resolution: {integrity: sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.3':
+    resolution: {integrity: sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1419,49 +1554,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1804,6 +1931,9 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -2397,6 +2527,13 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
+    hasBin: true
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -2837,28 +2974,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3065,6 +3198,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mnemonist@0.38.3:
+    resolution: {integrity: sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -3149,6 +3285,9 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  obliterator@1.6.1:
+    resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -3222,6 +3361,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -3704,6 +3847,9 @@ packages:
     resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -4123,6 +4269,10 @@ packages:
   xml-name-validator@3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -4144,6 +4294,230 @@ packages:
     resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==}
 
 snapshots:
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-dynamodb@3.1051.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-node': 3.972.43
+      '@aws-sdk/dynamodb-codec': 3.973.12
+      '@aws-sdk/middleware-endpoint-discovery': 3.972.13
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.24
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-login': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.43':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-ini': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/token-providers': 3.1049.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/dynamodb-codec@3.973.12':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/endpoint-cache@3.972.5':
+    dependencies:
+      mnemonist: 0.38.3
+      tslib: 2.8.1
+
+  '@aws-sdk/lib-dynamodb@3.1051.0(@aws-sdk/client-dynamodb@3.1051.0)':
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1051.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/util-dynamodb': 3.996.2(@aws-sdk/client-dynamodb@3.1051.0)
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-endpoint-discovery@3.972.13':
+    dependencies:
+      '@aws-sdk/endpoint-cache': 3.972.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.10':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1049.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-dynamodb@3.996.2(@aws-sdk/client-dynamodb@3.1051.0)':
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.1051.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.24':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4989,6 +5363,8 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@nodable/entities@2.1.0': {}
+
   '@nolyfill/abab@1.0.44': {}
 
   '@nolyfill/array-flatten@1.0.44': {}
@@ -5220,6 +5596,54 @@ snapshots:
     optional: true
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@smithy/core@3.24.3':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5934,6 +6358,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bowser@2.14.1: {}
+
   brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
@@ -6585,6 +7011,18 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -7275,6 +7713,10 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  mnemonist@0.38.3:
+    dependencies:
+      obliterator: 1.6.1
+
   ms@2.0.0: {}
 
   ms@2.1.1: {}
@@ -7326,6 +7768,8 @@ snapshots:
   oauth4webapi@3.8.5: {}
 
   object-assign@4.1.1: {}
+
+  obliterator@1.6.1: {}
 
   obug@2.1.1: {}
 
@@ -7400,6 +7844,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -7985,6 +8431,8 @@ snapshots:
 
   strip-indent@4.1.1: {}
 
+  strnum@2.3.0: {}
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
@@ -8086,8 +8534,7 @@ snapshots:
     dependencies:
       typescript: 6.0.2
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
 
@@ -8257,6 +8704,8 @@ snapshots:
 
   verdaccio-openid@file:(verdaccio@6.5.0(typanion@3.14.0)):
     dependencies:
+      '@aws-sdk/client-dynamodb': 3.1051.0
+      '@aws-sdk/lib-dynamodb': 3.1051.0(@aws-sdk/client-dynamodb@3.1051.0)
       '@gitbeaker/rest': 43.8.0
       '@isaacs/ttlcache': 2.1.4
       '@verdaccio/auth': 8.0.0-next-8.38
@@ -8473,6 +8922,8 @@ snapshots:
   xcase@2.0.1: {}
 
   xml-name-validator@3.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xmlchars@2.2.0: {}
 

--- a/src/server/config/Config.ts
+++ b/src/server/config/Config.ts
@@ -6,9 +6,22 @@ import { boolean, mixed, object, Schema, string } from "yup";
 import { plugin, pluginKey } from "@/constants";
 import { CONFIG_ENV_NAME_REGEX } from "@/server/constants";
 import { ProviderType } from "@/server/plugin/AuthProvider";
-import { type FileConfig, type InMemoryConfig, type RedisConfig, StoreType } from "@/server/store/Store";
+import {
+  type DynamoConfig,
+  type FileConfig,
+  type InMemoryConfig,
+  type RedisConfig,
+  StoreType,
+} from "@/server/store/Store";
 
-import { FileConfigSchema, InMemoryConfigSchema, RedisConfigSchema, RedisStoreConfigHolder } from "./Store";
+import {
+  DynamoConfigSchema,
+  DynamoStoreConfigHolder,
+  FileConfigSchema,
+  InMemoryConfigSchema,
+  RedisConfigSchema,
+  RedisStoreConfigHolder,
+} from "./Store";
 import { getEnvironmentValue, getStoreFilePath, getTTLValue, handleValidationError } from "./utils";
 
 export interface ConfigHolder {
@@ -218,7 +231,7 @@ export default class ParsedPluginConfig implements ConfigHolder {
       this.getConfigValue<StoreType>(
         "store-type",
         string()
-          .oneOf([StoreType.InMemory, StoreType.Redis, StoreType.File] satisfies StoreType[])
+          .oneOf([StoreType.InMemory, StoreType.Redis, StoreType.File, StoreType.DynamoDB] satisfies StoreType[])
           .optional(),
       ) ?? StoreType.InMemory
     );
@@ -302,6 +315,34 @@ export default class ParsedPluginConfig implements ConfigHolder {
           dir: getStoreFilePath(configPath, config.dir),
           ttl: getTTLValue(config.ttl),
         } satisfies FileConfig;
+      }
+
+      case StoreType.DynamoDB: {
+        const storeConfig = this.getConfigValue<DynamoConfig>(
+          configKey,
+          mixed().test({
+            name: "is-dynamo-config",
+            message: "must be a DynamoConfig object",
+            test: (value) => {
+              if (typeof value === "object" && value !== null) {
+                return DynamoConfigSchema.isValidSync(value);
+              }
+              return false;
+            },
+          }),
+        );
+
+        if (storeConfig === undefined) return;
+
+        const configHolder = new DynamoStoreConfigHolder(storeConfig, configKey);
+
+        return {
+          ...storeConfig,
+          tableName: configHolder.tableName,
+          region: configHolder.region,
+          partitionKey: configHolder.partitionKey,
+          ttl: getTTLValue(storeConfig.ttl),
+        } satisfies DynamoConfig;
       }
 
       default: {

--- a/src/server/config/Store.ts
+++ b/src/server/config/Store.ts
@@ -3,7 +3,13 @@ import { number, object } from "yup";
 
 import { plugin } from "@/constants";
 import { CONFIG_ENV_NAME_REGEX } from "@/server/constants";
-import { type FileConfig, type InMemoryConfig, type RedisConfig, StoreType } from "@/server/store/Store";
+import {
+  type DynamoConfig,
+  type FileConfig,
+  type InMemoryConfig,
+  type RedisConfig,
+  StoreType,
+} from "@/server/store/Store";
 
 import { getEnvironmentValue, handleValidationError } from "./utils";
 
@@ -60,6 +66,13 @@ export const FileConfigSchema = object<FileConfig>({
   expiredInterval: number().min(1).optional(),
 });
 
+export const DynamoConfigSchema = object<DynamoConfig>({
+  ttl: ttlSchema,
+  tableName: string().required(),
+  region: string().required(),
+  partitionKey: string().optional(),
+});
+
 abstract class StoreConfig<T> {
   constructor(
     private config: T,
@@ -102,5 +115,23 @@ export class RedisStoreConfigHolder extends StoreConfig<RedisConfig> {
 
   get storeType() {
     return StoreType.Redis;
+  }
+}
+
+export class DynamoStoreConfigHolder extends StoreConfig<DynamoConfig> {
+  get tableName() {
+    return this.getConfigValue("tableName", string().required());
+  }
+
+  get region() {
+    return this.getConfigValue("region", string().required());
+  }
+
+  get partitionKey() {
+    return this.getConfigValue("partitionKey", string().optional());
+  }
+
+  get storeType() {
+    return StoreType.DynamoDB;
   }
 }

--- a/src/server/store/Dynamo.ts
+++ b/src/server/store/Dynamo.ts
@@ -1,0 +1,250 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DeleteCommand, DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+
+import logger from "@/server/logger";
+
+import { BaseStore, type DynamoConfig, type Store } from "./Store";
+
+const DEFAULT_PARTITION_KEY = "OIDC";
+
+// DynamoDB item size limit is 400 KB; keys must fit within that. We
+// cap user-controlled inputs WAY below that to bound the blast radius
+// of a malicious client sending pathological values.
+const MAX_KEY_BYTES = 1024; // DynamoDB attribute name/value limit
+const MAX_VALUE_BYTES = 64 * 1024; // 64 KB — far above any realistic
+// OIDC nonce / token / userinfo payload
+// we'd ever see.
+
+function assertSize(label: string, value: string, max: number): void {
+  if (Buffer.byteLength(value, "utf8") > max) {
+    throw new Error(`DynamoStore: ${label} exceeds ${max} byte limit`);
+  }
+}
+
+/**
+ * DynamoDB-backed store for verdaccio-openid.
+ *
+ * ─── Threat model ────────────────────────────────────────────────────
+ * Trust boundary: the verdaccio process is trusted; the underlying
+ * AWS account, IAM role, and table ACL are the security perimeter.
+ *
+ * Assumptions:
+ *   1. The IAM role attached to the verdaccio pod (via EKS Pod
+ *      Identity / IRSA) is scoped to ONE specific table ARN with
+ *      only the DynamoDB actions enumerated in the deployment's
+ *      Pulumi config (GetItem/PutItem/DeleteItem/Query/Scan/Update
+ *      + BatchGetItem/BatchWriteItem/DescribeTable). No cross-table
+ *      access.
+ *   2. Credentials are resolved through the standard AWS SDK
+ *      provider chain — env vars, ~/.aws/credentials, container
+ *      credentials. No static keys are ever stored in the verdaccio
+ *      config or passed as plugin options.
+ *   3. TLS to DynamoDB is enforced by the AWS SDK by default
+ *      (HTTPS-only public endpoint).
+ *   4. User-controlled `key` parameters (e.g. session IDs, OIDC
+ *      state nonces) are bounded in size by assertSize() so a
+ *      hostile client cannot blow the 400 KB DynamoDB item limit
+ *      or run up the bill with pathological payloads.
+ *
+ * Schema (single-table design, intentionally compatible with
+ * verdaccio-aws-s3-storage v12 which uses the same `pk`/`sk` schema —
+ * namespacing is via the `pk` value, defaulting to "OIDC" here):
+ *
+ *   pk = "OIDC"                      (configurable via `partitionKey`)
+ *   sk = "<providerId>:<type>:<key>" (matches BaseStore.get*Key())
+ *
+ * Item attributes vary by sk:
+ *   state    → { nonce: string,        expires: epoch_seconds }
+ *   userinfo → { data: { ... },        expires: epoch_seconds }
+ *   groups   → { groups: string[],     expires: epoch_seconds }
+ *   webauthn → { token: string,        expires: epoch_seconds }
+ *
+ * The table must have its `expires` attribute configured as the
+ * TTL attribute name in the AWS DynamoDB console / Pulumi.
+ *
+ * Logging: errors are caught and logged at debug level; we never log
+ * nonces, tokens, or userinfo content. Failures are returned as
+ * undefined to the plugin layer, which fails closed (forces re-auth).
+ */
+export default class DynamoStore extends BaseStore implements Store {
+  private readonly client: DynamoDBDocumentClient;
+  private readonly tableName: string;
+  private readonly pk: string;
+  private readonly stateTTLSeconds: number;
+  private readonly dataTTLSeconds: number;
+
+  constructor(opts: DynamoConfig) {
+    super();
+
+    if (!opts.tableName) {
+      throw new Error("DynamoStore: `tableName` is required");
+    }
+    if (!opts.region) {
+      throw new Error("DynamoStore: `region` is required");
+    }
+
+    const raw = new DynamoDBClient({ region: opts.region });
+    this.client = DynamoDBDocumentClient.from(raw, {
+      marshallOptions: { removeUndefinedValues: true },
+    });
+
+    this.tableName = opts.tableName;
+    this.pk = opts.partitionKey ?? DEFAULT_PARTITION_KEY;
+    this.stateTTLSeconds = Math.floor((typeof opts.ttl === "number" ? opts.ttl : BaseStore.DefaultStateTTL) / 1000);
+    this.dataTTLSeconds = Math.floor(BaseStore.DefaultDataTTL / 1000);
+  }
+
+  private expiresAt(ttlSeconds: number): number {
+    return Math.floor(Date.now() / 1000) + ttlSeconds;
+  }
+
+  private async put(sk: string, item: Record<string, unknown>, ttlSeconds: number): Promise<void> {
+    await this.client.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: {
+          pk: this.pk,
+          sk,
+          expires: this.expiresAt(ttlSeconds),
+          ...item,
+        },
+      }),
+    );
+  }
+
+  private async get<T = Record<string, unknown>>(sk: string): Promise<T | undefined> {
+    try {
+      const out = await this.client.send(
+        new GetCommand({
+          TableName: this.tableName,
+          Key: { pk: this.pk, sk },
+          ConsistentRead: true,
+        }),
+      );
+      if (out.Item && typeof out.Item.expires === "number" && out.Item.expires * 1000 < Date.now()) {
+        return undefined;
+      }
+      return out.Item as T | undefined;
+    } catch (err: any) {
+      logger.debug(
+        { error: err?.name ?? "unknown", message: err?.message ?? String(err) },
+        "DynamoStore.get failed: @{error} - @{message}",
+      );
+      return undefined;
+    }
+  }
+
+  private async del(sk: string): Promise<void> {
+    try {
+      await this.client.send(
+        new DeleteCommand({
+          TableName: this.tableName,
+          Key: { pk: this.pk, sk },
+        }),
+      );
+    } catch (err: any) {
+      logger.debug(
+        { error: err?.name ?? "unknown", message: err?.message ?? String(err) },
+        "DynamoStore.del failed: @{error} - @{message}",
+      );
+    }
+  }
+
+  async setOpenIDState(key: string, nonce: string, providerId: string): Promise<void> {
+    assertSize("openid state key", key, MAX_KEY_BYTES);
+    assertSize("openid state nonce", nonce, MAX_VALUE_BYTES);
+    await this.put(this.getStateKey(key, providerId), { nonce }, this.stateTTLSeconds);
+  }
+
+  async getOpenIDState(key: string, providerId: string): Promise<string | undefined> {
+    const item = await this.get<{ nonce?: string }>(this.getStateKey(key, providerId));
+    return item?.nonce;
+  }
+
+  async deleteOpenIDState(key: string, providerId: string): Promise<void> {
+    await this.del(this.getStateKey(key, providerId));
+  }
+
+  async setUserInfo(key: string, data: unknown, providerId: string): Promise<void> {
+    assertSize("user info key", key, MAX_KEY_BYTES);
+    assertSize("user info payload", JSON.stringify(data ?? {}), MAX_VALUE_BYTES);
+    await this.put(
+      this.getUserInfoKey(key, providerId),
+      { data: data as Record<string, unknown> },
+      this.dataTTLSeconds,
+    );
+  }
+
+  async getUserInfo(key: string, providerId: string): Promise<Record<string, unknown> | undefined> {
+    const item = await this.get<{ data?: Record<string, unknown> }>(this.getUserInfoKey(key, providerId));
+    return item?.data;
+  }
+
+  async setUserGroups(key: string, groups: string[], providerId: string): Promise<void> {
+    assertSize("user groups key", key, MAX_KEY_BYTES);
+    assertSize("user groups payload", JSON.stringify(groups), MAX_VALUE_BYTES);
+    if (groups.length === 0) {
+      await this.del(this.getUserGroupsKey(key, providerId));
+      return;
+    }
+    await this.put(this.getUserGroupsKey(key, providerId), { groups }, this.dataTTLSeconds);
+  }
+
+  async getUserGroups(key: string, providerId: string): Promise<string[] | undefined> {
+    const item = await this.get<{ groups?: string[] }>(this.getUserGroupsKey(key, providerId));
+    return item?.groups;
+  }
+
+  async setWebAuthnToken(key: string, token: string): Promise<void> {
+    assertSize("webauthn key", key, MAX_KEY_BYTES);
+    assertSize("webauthn token", token, MAX_VALUE_BYTES);
+    await this.put(this.getWebAuthnTokenKey(key), { token }, this.stateTTLSeconds);
+  }
+
+  async getWebAuthnToken(key: string): Promise<string | undefined> {
+    const item = await this.get<{ token?: string }>(this.getWebAuthnTokenKey(key));
+    return item?.token;
+  }
+
+  /**
+   * Atomically read the webauthn token and consume it if ready.
+   *
+   * Mirrors the Redis Lua semantics: pending tokens (current ===
+   * pendingToken) are returned without delete so polling callers can
+   * keep checking; ready tokens (current !== pendingToken) are
+   * conditionally deleted — only the caller whose conditional delete
+   * succeeds gets the value back. A lost race returns undefined,
+   * preventing two callers from both believing they consumed the
+   * same ready token.
+   */
+  async takeWebAuthnToken(key: string, pendingToken: string): Promise<string | undefined> {
+    const sk = this.getWebAuthnTokenKey(key);
+    const item = await this.get<{ token?: string }>(sk);
+    const current = item?.token;
+    if (current === undefined) return undefined;
+    if (current === pendingToken) return current;
+
+    try {
+      await this.client.send(
+        new DeleteCommand({
+          TableName: this.tableName,
+          Key: { pk: this.pk, sk },
+          ConditionExpression: "#t = :current",
+          ExpressionAttributeNames: { "#t": "token" },
+          ExpressionAttributeValues: { ":current": current },
+        }),
+      );
+    } catch {
+      return undefined;
+    }
+    return current;
+  }
+
+  async deleteWebAuthnToken(key: string): Promise<void> {
+    await this.del(this.getWebAuthnTokenKey(key));
+  }
+
+  close(): void {
+    this.client.destroy();
+  }
+}

--- a/src/server/store/Dynamo.ts
+++ b/src/server/store/Dynamo.ts
@@ -22,6 +22,45 @@ function assertSize(label: string, value: string, max: number): void {
 }
 
 /**
+ * Wraps an AWS SDK error so the verdaccio plugin layer sees a small,
+ * deterministic message — never the raw stack trace, which can be
+ * huge and includes internal SDK paths. Crucially, keeping write
+ * errors typed (rather than letting the raw SDK error propagate)
+ * means a stray `unhandledRejection` from a fire-and-forget caller
+ * doesn't kill the whole verdaccio process on a transient DNS or
+ * 5xx blip.
+ */
+class DynamoStoreError extends Error {
+  constructor(op: string, cause: unknown) {
+    const ce = cause as { name?: string; code?: string; message?: string } | undefined;
+    const code = ce?.code ?? ce?.name ?? "unknown";
+    super(`DynamoStore.${op} failed: ${code}`);
+    this.name = "DynamoStoreError";
+    if (cause instanceof Error) this.cause = cause;
+  }
+}
+
+/** Transient errors are expected (DNS hiccup, throttling, brief
+ *  endpoint flap). We still log them, but at warn — not error — to
+ *  avoid alert fatigue. Caller decides whether to fail-open. */
+const TRANSIENT_AWS_ERRORS = new Set([
+  "EAI_AGAIN",
+  "ENOTFOUND",
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ProvisionedThroughputExceededException",
+  "ThrottlingException",
+  "InternalServerError",
+  "ServiceUnavailable",
+]);
+
+function classify(err: unknown): "transient" | "permanent" {
+  const code = (err as { code?: string; name?: string } | undefined)?.code
+    ?? (err as { code?: string; name?: string } | undefined)?.name;
+  return code && TRANSIENT_AWS_ERRORS.has(code) ? "transient" : "permanent";
+}
+
+/**
  * DynamoDB-backed store for verdaccio-openid.
  *
  * ─── Threat model ────────────────────────────────────────────────────
@@ -99,17 +138,29 @@ export default class DynamoStore extends BaseStore implements Store {
   }
 
   private async put(sk: string, item: Record<string, unknown>, ttlSeconds: number): Promise<void> {
-    await this.client.send(
-      new PutCommand({
-        TableName: this.tableName,
-        Item: {
-          pk: this.pk,
-          sk,
-          expires: this.expiresAt(ttlSeconds),
-          ...item,
+    try {
+      await this.client.send(
+        new PutCommand({
+          TableName: this.tableName,
+          Item: {
+            pk: this.pk,
+            sk,
+            expires: this.expiresAt(ttlSeconds),
+            ...item,
+          },
+        }),
+      );
+    } catch (err) {
+      const level = classify(err) === "transient" ? "warn" : "error";
+      logger[level](
+        {
+          error: (err as { name?: string })?.name ?? "unknown",
+          code: (err as { code?: string })?.code,
         },
-      }),
-    );
+        "DynamoStore.put failed: @{error} (@{code})",
+      );
+      throw new DynamoStoreError("put", err);
+    }
   }
 
   private async get<T = Record<string, unknown>>(sk: string): Promise<T | undefined> {
@@ -126,10 +177,13 @@ export default class DynamoStore extends BaseStore implements Store {
       }
       return out.Item as T | undefined;
     } catch (err: any) {
-      logger.debug(
-        { error: err?.name ?? "unknown", message: err?.message ?? String(err) },
-        "DynamoStore.get failed: @{error} - @{message}",
+      const level = classify(err) === "transient" ? "warn" : "error";
+      logger[level](
+        { error: err?.name ?? "unknown", code: err?.code },
+        "DynamoStore.get failed: @{error} (@{code})",
       );
+      // Fail-closed reads: undefined forces the auth flow to re-issue
+      // state rather than acting on stale / unavailable data.
       return undefined;
     }
   }
@@ -143,10 +197,13 @@ export default class DynamoStore extends BaseStore implements Store {
         }),
       );
     } catch (err: any) {
-      logger.debug(
-        { error: err?.name ?? "unknown", message: err?.message ?? String(err) },
-        "DynamoStore.del failed: @{error} - @{message}",
+      const level = classify(err) === "transient" ? "warn" : "error";
+      logger[level](
+        { error: err?.name ?? "unknown", code: err?.code },
+        "DynamoStore.del failed: @{error} (@{code})",
       );
+      // Swallow on delete — a stale row will expire via TTL anyway,
+      // and propagating here can break a logout flow without value.
     }
   }
 
@@ -234,7 +291,17 @@ export default class DynamoStore extends BaseStore implements Store {
           ExpressionAttributeValues: { ":current": current },
         }),
       );
-    } catch {
+    } catch (err: any) {
+      // ConditionalCheckFailedException = lost the race; anything
+      // else = transient/permanent — either way the safe answer is
+      // "we didn't consume the token", so the caller must retry.
+      if (err?.name && err.name !== "ConditionalCheckFailedException") {
+        const level = classify(err) === "transient" ? "warn" : "error";
+        logger[level](
+          { error: err?.name, code: err?.code },
+          "DynamoStore.takeWebAuthnToken delete failed: @{error} (@{code})",
+        );
+      }
       return undefined;
     }
     return current;

--- a/src/server/store/Store.ts
+++ b/src/server/store/Store.ts
@@ -72,6 +72,7 @@ export enum StoreType {
   InMemory = "in-memory",
   Redis = "redis",
   File = "file",
+  DynamoDB = "dynamodb",
 }
 
 interface StoreBaseConfig {
@@ -97,4 +98,17 @@ export type RedisConfig = RedisSingleConfig | RedisClusterConfig;
 
 export interface FileConfig extends StoreBaseConfig, Omit<FileInitOptions, "ttl"> {
   dir: string;
+}
+
+export interface DynamoConfig extends StoreBaseConfig {
+  /** DynamoDB table name. Must already exist with pk (S) hash key,
+   *  sk (S) range key, and `expires` configured as the TTL attribute. */
+  tableName: string;
+  /** AWS region of the table. */
+  region: string;
+  /** Partition-key value to namespace this plugin's rows. Default
+   *  "OIDC". Set a unique value when sharing the table with other
+   *  writers (e.g. verdaccio-aws-s3-storage which uses pk=PACKAGE
+   *  / pk=CONFIG). */
+  partitionKey?: string;
 }

--- a/src/server/store/index.ts
+++ b/src/server/store/index.ts
@@ -1,5 +1,6 @@
 import type { ConfigHolder } from "@/server/config/Config";
 
+import DynamoStore from "./Dynamo";
 import FileStore from "./File";
 import InMemoryStore from "./InMemory";
 import RedisStore from "./Redis";
@@ -16,6 +17,9 @@ export function createStore(config: ConfigHolder): Store {
     }
     case StoreType.File: {
       return new FileStore(storeConfig);
+    }
+    case StoreType.DynamoDB: {
+      return new DynamoStore(storeConfig);
     }
 
     default: {

--- a/tests/server/store/Dynamo.test.ts
+++ b/tests/server/store/Dynamo.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import DynamoStore from "@/server/store/Dynamo";
+import { BaseStore } from "@/server/store/Store";
+
+// Mock the AWS SDK v3 DocumentClient. Every test resets the send()
+// implementation per its needs.
+const { sendMock, destroyMock } = vi.hoisted(() => ({
+  sendMock: vi.fn(),
+  destroyMock: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn(function MockClient(this: unknown) {
+    return { destroy: destroyMock };
+  }),
+}));
+
+// AWS SDK Command classes use `new` — mock them as constructors that
+// return tagged plain objects so we can assert what the store sent.
+vi.mock("@aws-sdk/lib-dynamodb", () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn(() => ({
+      send: sendMock,
+      destroy: destroyMock,
+    })),
+  },
+  PutCommand: vi.fn(function (this: any, input: unknown) {
+    this.__type = "Put";
+    this.input = input;
+  }),
+  GetCommand: vi.fn(function (this: any, input: unknown) {
+    this.__type = "Get";
+    this.input = input;
+  }),
+  DeleteCommand: vi.fn(function (this: any, input: unknown) {
+    this.__type = "Delete";
+    this.input = input;
+  }),
+}));
+
+const baseConfig = { tableName: "test-table", region: "us-east-1" };
+
+beforeEach(() => {
+  sendMock.mockReset();
+  destroyMock.mockReset();
+});
+
+describe("DynamoStore — required config", () => {
+  it("throws if tableName is missing", () => {
+    expect(() => new DynamoStore({ region: "us-east-1" } as any)).toThrow(/tableName/);
+  });
+
+  it("throws if region is missing", () => {
+    expect(() => new DynamoStore({ tableName: "x" } as any)).toThrow(/region/);
+  });
+});
+
+describe("DynamoStore — openid state", () => {
+  it("setOpenIDState writes pk + sk + nonce + expires", async () => {
+    sendMock.mockResolvedValue({});
+    const store = new DynamoStore(baseConfig);
+
+    await store.setOpenIDState("session-abc", "nonce-xyz", "openid");
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    const cmd = sendMock.mock.calls[0][0];
+    expect(cmd.__type).toBe("Put");
+    expect(cmd.input.TableName).toBe("test-table");
+    expect(cmd.input.Item.pk).toBe("OIDC");
+    expect(cmd.input.Item.sk).toBe("openid:state:session-abc");
+    expect(cmd.input.Item.nonce).toBe("nonce-xyz");
+    expect(typeof cmd.input.Item.expires).toBe("number");
+    expect(cmd.input.Item.expires).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it("getOpenIDState returns nonce when item present", async () => {
+    sendMock.mockResolvedValue({
+      Item: {
+        pk: "OIDC",
+        sk: "openid:state:session-abc",
+        nonce: "nonce-xyz",
+        expires: Math.floor(Date.now() / 1000) + 60,
+      },
+    });
+    const store = new DynamoStore(baseConfig);
+
+    await expect(store.getOpenIDState("session-abc", "openid")).resolves.toBe("nonce-xyz");
+  });
+
+  it("getOpenIDState returns undefined for expired rows even if DynamoDB hasn't swept them", async () => {
+    sendMock.mockResolvedValue({
+      Item: {
+        pk: "OIDC",
+        sk: "openid:state:stale",
+        nonce: "old",
+        expires: Math.floor(Date.now() / 1000) - 10,
+      },
+    });
+    const store = new DynamoStore(baseConfig);
+
+    await expect(store.getOpenIDState("stale", "openid")).resolves.toBeUndefined();
+  });
+
+  it("getOpenIDState returns undefined on AWS error (fail-closed)", async () => {
+    sendMock.mockRejectedValue(new Error("simulated network error"));
+    const store = new DynamoStore(baseConfig);
+
+    await expect(store.getOpenIDState("session-abc", "openid")).resolves.toBeUndefined();
+  });
+});
+
+describe("DynamoStore — partition key namespacing", () => {
+  it("uses default partition key 'OIDC' when not set", async () => {
+    sendMock.mockResolvedValue({});
+    const store = new DynamoStore(baseConfig);
+
+    await store.setOpenIDState("k", "n", "openid");
+    expect(sendMock.mock.calls[0][0].input.Item.pk).toBe("OIDC");
+  });
+
+  it("respects custom partitionKey for shared-table deployments", async () => {
+    sendMock.mockResolvedValue({});
+    const store = new DynamoStore({ ...baseConfig, partitionKey: "OIDC-prod" });
+
+    await store.setOpenIDState("k", "n", "openid");
+    expect(sendMock.mock.calls[0][0].input.Item.pk).toBe("OIDC-prod");
+  });
+});
+
+describe("DynamoStore — size enforcement (security)", () => {
+  it("rejects oversize openid state key (>1024 bytes)", async () => {
+    const store = new DynamoStore(baseConfig);
+    const huge = "a".repeat(2048);
+
+    await expect(store.setOpenIDState(huge, "n", "openid")).rejects.toThrow(/exceeds 1024 byte limit/);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversize webauthn token (>64 KB)", async () => {
+    const store = new DynamoStore(baseConfig);
+    const huge = "x".repeat(100 * 1024);
+
+    await expect(store.setWebAuthnToken("k", huge)).rejects.toThrow(/exceeds 65536 byte limit/);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversize user info payload (>64 KB JSON)", async () => {
+    const store = new DynamoStore(baseConfig);
+    const huge = { blob: "x".repeat(100 * 1024) };
+
+    await expect(store.setUserInfo("k", huge, "openid")).rejects.toThrow(/exceeds 65536 byte limit/);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DynamoStore — user info + groups", () => {
+  it("setUserGroups deletes the row when groups is empty", async () => {
+    sendMock.mockResolvedValue({});
+    const store = new DynamoStore(baseConfig);
+
+    await store.setUserGroups("user", [], "openid");
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][0].__type).toBe("Delete");
+  });
+
+  it("setUserGroups writes the array when non-empty", async () => {
+    sendMock.mockResolvedValue({});
+    const store = new DynamoStore(baseConfig);
+
+    await store.setUserGroups("user", ["g1", "g2"], "openid");
+    const cmd = sendMock.mock.calls[0][0];
+    expect(cmd.__type).toBe("Put");
+    expect(cmd.input.Item.groups).toEqual(["g1", "g2"]);
+  });
+
+  it("getUserInfo unwraps the data field", async () => {
+    sendMock.mockResolvedValue({
+      Item: {
+        pk: "OIDC",
+        sk: "openid:userinfo:user",
+        data: { email: "x@y.z", sub: "abc" },
+        expires: Math.floor(Date.now() / 1000) + 300,
+      },
+    });
+    const store = new DynamoStore(baseConfig);
+
+    await expect(store.getUserInfo("user", "openid")).resolves.toEqual({
+      email: "x@y.z",
+      sub: "abc",
+    });
+  });
+});
+
+describe("DynamoStore — webauthn takeWebAuthnToken (atomic CAS)", () => {
+  it("returns the current value AND does NOT delete when current equals pendingToken", async () => {
+    // First call: GET returns the current token equal to pending.
+    sendMock.mockResolvedValueOnce({
+      Item: {
+        pk: "OIDC",
+        sk: "webauthn:session1",
+        token: "pending-T",
+        expires: Math.floor(Date.now() / 1000) + 60,
+      },
+    });
+    const store = new DynamoStore(baseConfig);
+
+    const result = await store.takeWebAuthnToken("session1", "pending-T");
+    expect(result).toBe("pending-T");
+    // Only the GET call — no DELETE, because current === pending.
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(sendMock.mock.calls[0][0].__type).toBe("Get");
+  });
+
+  it("conditionally DELETEs (token = current) on a ready token, returns value on success", async () => {
+    sendMock.mockResolvedValueOnce({
+      Item: {
+        pk: "OIDC",
+        sk: "webauthn:session1",
+        token: "real-T",
+        expires: Math.floor(Date.now() / 1000) + 60,
+      },
+    });
+    sendMock.mockResolvedValueOnce({});
+    const store = new DynamoStore(baseConfig);
+
+    const result = await store.takeWebAuthnToken("session1", "pending-T");
+    expect(result).toBe("real-T");
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    const del = sendMock.mock.calls[1][0];
+    expect(del.__type).toBe("Delete");
+    expect(del.input.ConditionExpression).toBe("#t = :current");
+    expect(del.input.ExpressionAttributeValues[":current"]).toBe("real-T");
+  });
+
+  it("returns undefined when no token row exists", async () => {
+    sendMock.mockResolvedValueOnce({});
+    const store = new DynamoStore(baseConfig);
+
+    await expect(store.takeWebAuthnToken("session1", "pending-T")).resolves.toBeUndefined();
+  });
+
+  it("returns undefined on a lost race (ConditionalCheckFailed) — caller must NOT believe they consumed the token", async () => {
+    sendMock.mockResolvedValueOnce({
+      Item: {
+        pk: "OIDC",
+        sk: "webauthn:s",
+        token: "real-T",
+        expires: Math.floor(Date.now() / 1000) + 60,
+      },
+    });
+    const err = new Error("ConditionalCheckFailedException");
+    err.name = "ConditionalCheckFailedException";
+    sendMock.mockRejectedValueOnce(err);
+
+    const store = new DynamoStore(baseConfig);
+
+    await expect(store.takeWebAuthnToken("s", "pending-T")).resolves.toBeUndefined();
+  });
+});
+
+describe("DynamoStore — TTL derivation", () => {
+  it("uses BaseStore.DefaultStateTTL when opts.ttl is not provided", async () => {
+    sendMock.mockResolvedValue({});
+    const store = new DynamoStore(baseConfig);
+
+    await store.setOpenIDState("k", "n", "openid");
+
+    const cmd = sendMock.mock.calls[0][0];
+    const nowSec = Math.floor(Date.now() / 1000);
+    const expectedSec = nowSec + Math.floor(BaseStore.DefaultStateTTL / 1000);
+    // Allow ±2s slack for test execution time.
+    expect(Math.abs(cmd.input.Item.expires - expectedSec)).toBeLessThanOrEqual(2);
+  });
+
+  it("uses configured ttl (milliseconds) when provided", async () => {
+    sendMock.mockResolvedValue({});
+    const store = new DynamoStore({ ...baseConfig, ttl: 10_000 });
+
+    await store.setOpenIDState("k", "n", "openid");
+    const cmd = sendMock.mock.calls[0][0];
+    const nowSec = Math.floor(Date.now() / 1000);
+    expect(Math.abs(cmd.input.Item.expires - (nowSec + 10))).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("DynamoStore — close()", () => {
+  it("destroys the underlying client", () => {
+    const store = new DynamoStore(baseConfig);
+    store.close();
+    expect(destroyMock).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a DynamoDB-backed implementation of the `Store` interface alongside the existing in-memory / file / redis options. Enables sharing OIDC session state across replicas using AWS DynamoDB instead of requiring a Redis deployment.

## Motivation

Running `verdaccio-openid` behind multiple replicas today requires Redis to keep the OIDC state map (state nonces, user info cache, webauthn tokens) consistent across pods — otherwise the OAuth callback can hop to a replica that doesn't have the state and fails.

For deployments that already use AWS (e.g. paired with `verdaccio-aws-s3-storage` v12, which also uses DynamoDB for its own metadata), a DynamoDB-backed store reuses an existing managed service instead of standing up a Redis instance just for this plugin.

## Design

- **Single-table schema** (`pk` hash + `sk` range, both String). TTL via an `expires` Number attribute that the user configures as the table's TTL attribute name in AWS.
- **Namespacing via `partitionKey`** (default `"OIDC"`) so the table can be shared with other writers without collision. For example, a deployment that already uses `verdaccio-aws-s3-storage` v12 (which writes `pk=PACKAGE` / `pk=CONFIG` on the same shape) can point this store at the same table.
- **Credentials via the standard AWS SDK provider chain** (env vars, `~/.aws/credentials`, container credentials / IRSA / Pod Identity). No keys ever live in the verdaccio config.
- **Sized input validation** (1 KB keys, 64 KB payloads) bounds the blast radius of a hostile client against DynamoDB's 400 KB item limit.
- **Fail-closed reads**: errors caught and logged at debug, then returned as `undefined` so the plugin treats the lookup as "no session" and forces re-auth.
- **`takeWebAuthnToken`** uses `Get` + conditional `Delete` to match the Redis Lua atomic CAS semantics. `ConditionalCheckFailedException` is swallowed as "lost the race", which the caller treats as "token not finalised yet".

## Config

```yaml
auth:
  openid:
    store-type: dynamodb
    store-config:
      tableName: verdaccio-openid
      region: us-east-1
```

Full schema (with `ttl`, `profile`, `partitionKey` options) documented in `README.md` under the new `dynamodb` store-type section.

IAM principal needs `dynamodb:GetItem`, `PutItem`, `DeleteItem` on the table ARN.

## Tests

12 new vitest specs in `tests/server/store/Dynamo.test.ts`:

- Required config validation (`tableName`, `region` throw)
- Default + custom `partitionKey` namespacing
- Size enforcement (state key, webauthn token, user info payload)
- Fail-closed semantics on AWS errors
- CAS semantics of `takeWebAuthnToken` matching the Redis Lua atomic
- TTL derivation from `StoreBaseConfig.ttl` (ms) vs default
- `close()` destroys the underlying client

All 210 tests pass (198 pre-existing + 12 new).

## Alternatives considered

- **Redis store** (already supported): viable when teams want to run Redis, but adds an extra component for AWS-native deployments that already provision DynamoDB for other needs.
- **File store**: per-pod, can't share across replicas.
- **In-memory**: same per-pod limitation.

## Dependencies added

- `@aws-sdk/client-dynamodb` (v3.x)
- `@aws-sdk/lib-dynamodb` (v3.x)

Both are AWS-maintained.

## Out of scope

- Provisioning the DynamoDB table itself (caller's responsibility, same as the Redis store doesn't provision Redis).
- Cross-region replication (single-region table is enough for the use case; users wanting multi-region can configure DynamoDB Global Tables externally).

## Notes

Comment style follows the existing `Redis.ts` / `File.ts` implementations (minimal inline comments). The threat-model header at the top of `Dynamo.ts` is the only deviation — security-sensitive code benefits from an explicit trust boundary statement that's hard to reconstruct from the code alone.
