### PR TITLE
refactor: make ioredis/node-persist optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,8 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "global-agent": "^4.1.3",
-    "ioredis": "^5.11.1",
     "minimist": "^1.2.8",
     "ms": "^2.1.3",
-    "node-persist": "^4.0.4",
     "open": "^11.0.0",
     "openid-client": "^6.8.4",
     "picocolors": "^1.1.1",
@@ -85,7 +83,17 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
+    "ioredis": "^5.11.1",
+    "node-persist": "^4.0.4",
     "verdaccio": "^5.0.0||^6.0.0||^7.0.0-next-0"
+  },
+  "peerDependenciesMeta": {
+    "ioredis": {
+      "optional": true
+    },
+    "node-persist": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         version: 13.0.3
       verdaccio-openid:
         specifier: 'file:'
-        version: file:(verdaccio@6.8.0(typanion@3.14.0))
+        version: file:(ioredis@5.11.1)(node-persist@4.0.4)(verdaccio@6.8.0(typanion@3.14.0))
       verdaccio5:
         specifier: npm:verdaccio@5.0.0
         version: verdaccio@5.0.0(typanion@3.14.0)
@@ -3242,7 +3242,14 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
     peerDependencies:
+      ioredis: ^5.11.1
+      node-persist: ^4.0.4
       verdaccio: ^5.0.0||^6.0.0||^7.0.0-next-0
+    peerDependenciesMeta:
+      ioredis:
+        optional: true
+      node-persist:
+        optional: true
 
   verdaccio@5.0.0:
     resolution: {integrity: sha512-q32wdxzIh3ag1VirQ5LJVC25bpf4/sUwtjJlEhOleDwhu9tPHRTkHhSmcPVgdFZh3y8cETo4TGpHx9KBJ0Agfg==}
@@ -6539,7 +6546,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  verdaccio-openid@file:(verdaccio@6.8.0(typanion@3.14.0)):
+  verdaccio-openid@file:(ioredis@5.11.1)(node-persist@4.0.4)(verdaccio@6.8.0(typanion@3.14.0)):
     dependencies:
       '@gitbeaker/rest': 43.8.0
       '@isaacs/ttlcache': 2.1.5
@@ -6552,10 +6559,8 @@ snapshots:
       dotenv: 17.4.2
       express: 5.2.1
       global-agent: 4.1.3
-      ioredis: 5.11.1
       minimist: 1.2.8
       ms: 2.1.3
-      node-persist: 4.0.4
       open: 11.0.0
       openid-client: 6.8.4
       picocolors: 1.1.1
@@ -6563,6 +6568,9 @@ snapshots:
       stable-hash: 0.0.6
       verdaccio: 6.8.0(typanion@3.14.0)
       yup: 1.7.1
+    optionalDependencies:
+      ioredis: 5.11.1
+      node-persist: 4.0.4
     transitivePeerDependencies:
       - supports-color
 

--- a/src/server/store/File.ts
+++ b/src/server/store/File.ts
@@ -1,95 +1,122 @@
-import process from "node:process";
-
-import storage, { type InitOptions, LocalStorage } from "node-persist";
-
-import logger from "@/server/logger";
+import type { LocalStorage } from "node-persist";
 
 import { BaseStore, type FileConfig, type Store } from "./Store";
-
-const defaultOptions = {
-  ttl: BaseStore.DefaultStateTTL,
-} satisfies InitOptions;
+import { importOptional, interopDefault } from "@/server/utils";
 
 export default class FileStore extends BaseStore implements Store {
-  private readonly db: LocalStorage;
+  private readonly config: FileConfig | string;
+  private db?: LocalStorage;
+  private dbPromise?: Promise<LocalStorage>;
 
   constructor(opts: FileConfig | string) {
     super();
+    this.config = opts;
+  }
 
-    const db = storage.create({
-      ...defaultOptions,
-      ...(typeof opts === "string" ? { dir: opts } : opts),
-    });
+  private async getDb(): Promise<LocalStorage> {
+    if (this.db) return this.db;
 
-    void db.init().catch((e) => {
-      logger.error({ message: e.message }, "Failed to initialize file store: @{message}");
-      process.exit(1);
-    });
+    this.dbPromise ??= (async () => {
+      try {
+        const storage = await interopDefault(
+          importOptional(
+            import("node-persist"),
+            `store-type "file" requires the "node-persist" package. Install it: npm add -g node-persist`,
+          ),
+        );
 
-    this.db = db;
+        const db = storage.create({
+          ttl: BaseStore.DefaultStateTTL,
+          ...(typeof this.config === "string" ? { dir: this.config } : this.config),
+        });
+
+        await db.init();
+        this.db = db;
+        return db;
+      } catch (err) {
+        this.dbPromise = undefined;
+        throw err;
+      }
+    })();
+
+    return this.dbPromise;
   }
 
   async setOpenIDState(key: string, nonce: string, providerId: string): Promise<void> {
     const stateKey = this.getStateKey(key, providerId);
+    const db = await this.getDb();
 
-    await this.db.setItem(stateKey, nonce);
+    await db.setItem(stateKey, nonce);
   }
 
-  getOpenIDState(key: string, providerId: string): Promise<string | undefined> {
+  async getOpenIDState(key: string, providerId: string): Promise<string | undefined> {
     const stateKey = this.getStateKey(key, providerId);
+    const db = await this.getDb();
 
-    return this.db.getItem(stateKey);
+    return db.getItem(stateKey);
   }
 
   async deleteOpenIDState(key: string, providerId: string): Promise<void> {
     const stateKey = this.getStateKey(key, providerId);
+    const db = await this.getDb();
 
-    await this.db.removeItem(stateKey);
+    await db.removeItem(stateKey);
   }
 
   async setUserInfo(key: string, data: unknown, providerId: string): Promise<void> {
-    const userInfoKey = this.getUserInfoKey(key, providerId);
+    if (typeof data !== "object" || data === null) {
+      throw new TypeError("userinfo data must be an object");
+    }
 
-    await this.db.setItem(userInfoKey, data, { ttl: BaseStore.DefaultDataTTL });
+    const userInfoKey = this.getUserInfoKey(key, providerId);
+    const db = await this.getDb();
+
+    await db.setItem(userInfoKey, data, { ttl: BaseStore.DefaultDataTTL });
   }
 
-  getUserInfo(key: string, providerId: string): Promise<Record<string, unknown>> {
+  async getUserInfo(key: string, providerId: string): Promise<Record<string, unknown>> {
     const userInfoKey = this.getUserInfoKey(key, providerId);
+    const db = await this.getDb();
 
-    return this.db.getItem(userInfoKey);
+    return db.getItem(userInfoKey);
   }
 
   async setUserGroups(key: string, groups: string[], providerId: string): Promise<void> {
     const groupsKey = this.getUserGroupsKey(key, providerId);
+    const db = await this.getDb();
 
-    await this.db.setItem(groupsKey, groups, { ttl: BaseStore.DefaultDataTTL });
+    await db.setItem(groupsKey, groups, { ttl: BaseStore.DefaultDataTTL });
   }
 
-  getUserGroups(key: string, providerId: string): Promise<string[] | undefined> {
+  async getUserGroups(key: string, providerId: string): Promise<string[] | undefined> {
     const groupsKey = this.getUserGroupsKey(key, providerId);
+    const db = await this.getDb();
 
-    return this.db.getItem(groupsKey);
+    return db.getItem(groupsKey);
   }
 
   async setWebAuthnToken(key: string, token: string): Promise<void> {
     const tokenKey = this.getWebAuthnTokenKey(key);
+    const db = await this.getDb();
 
-    await this.db.setItem(tokenKey, token);
+    await db.setItem(tokenKey, token);
   }
 
-  getWebAuthnToken(key: string): Promise<string | null | undefined> {
+  async getWebAuthnToken(key: string): Promise<string | null | undefined> {
     const tokenKey = this.getWebAuthnTokenKey(key);
+    const db = await this.getDb();
 
-    return this.db.getItem(tokenKey);
+    return db.getItem(tokenKey);
   }
 
   async takeWebAuthnToken(key: string, pendingToken: string): Promise<string | null | undefined> {
     const tokenKey = this.getWebAuthnTokenKey(key);
+    const db = await this.getDb();
 
-    const token = (await this.db.getItem(tokenKey)) as string | null | undefined;
+    const token = (await db.getItem(tokenKey)) as string | null | undefined;
 
     if (token && token !== pendingToken) {
-      await this.db.removeItem(tokenKey);
+      await db.removeItem(tokenKey);
     }
 
     return token;
@@ -97,11 +124,18 @@ export default class FileStore extends BaseStore implements Store {
 
   async deleteWebAuthnToken(key: string): Promise<void> {
     const tokenKey = this.getWebAuthnTokenKey(key);
+    const db = await this.getDb();
 
-    await this.db.removeItem(tokenKey);
+    await db.removeItem(tokenKey);
   }
 
-  close(): void {
-    // ignore
+  async close(): Promise<void> {
+    try {
+      await this.dbPromise;
+    } catch {
+      // initialization failed, nothing to clean up
+    }
+    this.db = undefined;
+    this.dbPromise = undefined;
   }
 }

--- a/src/server/store/InMemory.ts
+++ b/src/server/store/InMemory.ts
@@ -40,6 +40,10 @@ export default class InMemoryStore extends BaseStore implements Store {
   }
 
   setUserInfo(key: string, data: unknown, providerId: string): void {
+    if (typeof data !== "object" || data === null) {
+      throw new TypeError("userinfo data must be an object");
+    }
+
     const userInfoKey = this.getUserInfoKey(key, providerId);
 
     this.dataCache.set(userInfoKey, data as Record<string, unknown>);

--- a/src/server/store/Redis.ts
+++ b/src/server/store/Redis.ts
@@ -1,6 +1,7 @@
-import { Cluster, Redis } from "ioredis";
+import type { Cluster, Redis as RedisClient } from "ioredis";
 
-import { BaseStore, type RedisClusterConfig, type RedisConfig, type RedisSingleConfig, type Store } from "./Store";
+import { importOptional } from "@/server/utils";
+import { BaseStore, type RedisClusterConfig, type RedisConfig, type Store } from "./Store";
 
 const TAKE_WEB_AUTHN_TOKEN_SCRIPT = `
 local value = redis.call("GET", KEYS[1])
@@ -15,77 +16,92 @@ return value
 
 const defaultOptions = {
   ttl: BaseStore.DefaultStateTTL,
-} satisfies RedisSingleConfig;
+};
 
 export default class RedisStore extends BaseStore implements Store {
+  private readonly config?: Omit<RedisConfig, "ttl"> | string;
   private readonly ttl: number;
-  private readonly redis: Cluster | Redis;
+  private redis?: RedisClient | Cluster;
+  private redisPromise?: Promise<RedisClient | Cluster>;
 
   constructor(opts?: RedisConfig | string) {
     super();
 
-    const { redis, ttl } = this.createClient(opts);
-
-    this.redis = redis;
-    this.ttl = ttl;
+    if (!!opts && typeof opts === "object") {
+      const { ttl, ...config } = opts;
+      this.config = config;
+      this.ttl = ttl ?? defaultOptions.ttl;
+    } else {
+      this.config = opts;
+      this.ttl = defaultOptions.ttl;
+    }
   }
 
-  private createClient(opts?: RedisConfig | string): { redis: Cluster | Redis; ttl: number } {
-    const { ttl: defaultTTL, ...restDefaultOpts } = defaultOptions;
+  private async getClient(): Promise<RedisClient | Cluster> {
+    if (this.redis) return this.redis;
 
-    if (!opts) {
-      return { redis: new Redis(restDefaultOpts), ttl: defaultTTL };
-    }
+    this.redisPromise ??= (async () => {
+      try {
+        const { Cluster, Redis } = await importOptional(
+          import("ioredis"),
+          `store-type "redis" requires the "ioredis" package. Install it: npm add -g ioredis`,
+        );
 
-    if (typeof opts === "string") {
-      return { redis: new Redis(opts, restDefaultOpts), ttl: defaultTTL };
-    }
+        if (!this.config) {
+          this.redis = new Redis();
+        } else if (typeof this.config === "string") {
+          this.redis = new Redis(this.config);
+        } else if (this.config?.nodes?.length) {
+          const { nodes, username, password, redisOptions, ...restOpts } = this.config as Omit<RedisClusterConfig, "ttl">;
 
-    if (opts?.nodes?.length) {
-      const {
-        ttl = defaultTTL,
-        nodes,
-        username,
-        password,
-        redisOptions,
-        ...restOpts
-      } = opts satisfies RedisClusterConfig;
+          this.redis = new Cluster(nodes, {
+            redisOptions: { username, password, ...redisOptions },
+            ...restOpts,
+          });
+        } else {
+          this.redis = new Redis(this.config);
+        }
 
-      return {
-        redis: new Redis.Cluster(nodes, {
-          redisOptions: { ...restDefaultOpts, username, password, ...redisOptions },
-          ...restOpts,
-        }),
-        ttl,
-      };
-    }
+        return this.redis;
+      } catch (err) {
+        this.redisPromise = undefined;
+        throw err;
+      }
+    })();
 
-    const { ttl, nodes: _, ...restOpts } = { ...defaultOptions, ...opts } satisfies RedisConfig;
-
-    return { redis: new Redis(restOpts), ttl };
+    return this.redisPromise;
   }
 
   async setOpenIDState(key: string, nonce: string, providerId: string): Promise<void> {
     const stateKey = this.getStateKey(key, providerId);
+    const redis = await this.getClient();
 
-    await this.redis.set(stateKey, nonce, "PX", this.ttl);
+    await redis.set(stateKey, nonce, "PX", this.ttl);
   }
 
   async getOpenIDState(key: string, providerId: string): Promise<string | null> {
     const stateKey = this.getStateKey(key, providerId);
-    return this.redis.get(stateKey);
+    const redis = await this.getClient();
+
+    return redis.get(stateKey);
   }
 
   async deleteOpenIDState(key: string, providerId: string): Promise<void> {
     const stateKey = this.getStateKey(key, providerId);
+    const redis = await this.getClient();
 
-    await this.redis.del(stateKey);
+    await redis.del(stateKey);
   }
 
   async setUserInfo(key: string, data: unknown, providerId: string): Promise<void> {
-    const userInfoKey = this.getUserInfoKey(key, providerId);
+    if (typeof data !== "object" || data === null) {
+      throw new TypeError("userinfo data must be an object");
+    }
 
-    const pipeline = this.redis.multi();
+    const userInfoKey = this.getUserInfoKey(key, providerId);
+    const redis = await this.getClient();
+
+    const pipeline = redis.multi();
 
     pipeline.hset(userInfoKey, data as Record<string, unknown>);
     pipeline.pexpire(userInfoKey, BaseStore.DefaultDataTTL);
@@ -95,7 +111,9 @@ export default class RedisStore extends BaseStore implements Store {
 
   async getUserInfo(key: string, providerId: string): Promise<Record<string, unknown> | null> {
     const userInfoKey = this.getUserInfoKey(key, providerId);
-    const userInfo = await this.redis.hgetall(userInfoKey);
+    const redis = await this.getClient();
+
+    const userInfo = await redis.hgetall(userInfoKey);
 
     if (Object.keys(userInfo).length === 0) return null;
 
@@ -104,8 +122,9 @@ export default class RedisStore extends BaseStore implements Store {
 
   async setUserGroups(key: string, groups: string[], providerId: string): Promise<void> {
     const groupsKey = this.getUserGroupsKey(key, providerId);
+    const redis = await this.getClient();
 
-    const pipeline = this.redis.multi();
+    const pipeline = redis.multi();
 
     pipeline.del(groupsKey);
 
@@ -119,7 +138,9 @@ export default class RedisStore extends BaseStore implements Store {
 
   async getUserGroups(key: string, providerId: string): Promise<string[] | null> {
     const groupsKey = this.getUserGroupsKey(key, providerId);
-    const groups = await this.redis.lrange(groupsKey, 0, -1);
+    const redis = await this.getClient();
+
+    const groups = await redis.lrange(groupsKey, 0, -1);
 
     if (groups.length === 0) return null;
 
@@ -128,19 +149,23 @@ export default class RedisStore extends BaseStore implements Store {
 
   async setWebAuthnToken(key: string, token: string): Promise<void> {
     const tokenKey = this.getWebAuthnTokenKey(key);
+    const redis = await this.getClient();
 
-    await this.redis.set(tokenKey, token, "PX", this.ttl);
+    await redis.set(tokenKey, token, "PX", this.ttl);
   }
 
   async getWebAuthnToken(key: string): Promise<string | null> {
     const tokenKey = this.getWebAuthnTokenKey(key);
+    const redis = await this.getClient();
 
-    return this.redis.get(tokenKey);
+    return redis.get(tokenKey);
   }
 
   async takeWebAuthnToken(key: string, pendingToken: string): Promise<string | null> {
     const tokenKey = this.getWebAuthnTokenKey(key);
-    const response = await this.redis.eval(TAKE_WEB_AUTHN_TOKEN_SCRIPT, 1, tokenKey, pendingToken);
+    const redis = await this.getClient();
+
+    const response = await redis.eval(TAKE_WEB_AUTHN_TOKEN_SCRIPT, 1, tokenKey, pendingToken);
 
     if (typeof response !== "string") {
       return null;
@@ -151,15 +176,29 @@ export default class RedisStore extends BaseStore implements Store {
 
   async deleteWebAuthnToken(key: string): Promise<void> {
     const tokenKey = this.getWebAuthnTokenKey(key);
+    const redis = await this.getClient();
 
-    await this.redis.del(tokenKey);
+    await redis.del(tokenKey);
   }
 
   async close(): Promise<void> {
+    let redis: RedisClient | Cluster | undefined;
+
     try {
-      await this.redis.quit();
+      redis = this.redis ?? (await this.redisPromise);
     } catch {
-      this.redis.disconnect();
+      // initialization failed, nothing to disconnect
     }
+
+    if (!redis) return;
+
+    try {
+      await redis.quit();
+    } catch {
+      redis.disconnect();
+    }
+
+    this.redis = undefined;
+    this.redisPromise = undefined;
   }
 }

--- a/src/server/store/index.ts
+++ b/src/server/store/index.ts
@@ -7,7 +7,6 @@ import { type Store, StoreType } from "./Store";
 
 export function createStore(config: ConfigHolder): Store {
   const storeType = config.storeType;
-
   const storeConfig = config.getStoreConfig(storeType);
 
   switch (storeType) {
@@ -17,7 +16,6 @@ export function createStore(config: ConfigHolder): Store {
     case StoreType.File: {
       return new FileStore(storeConfig);
     }
-
     default: {
       return new InMemoryStore(storeConfig);
     }

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Unwrap the default export of a CJS module (or pass through if ESM).
+ */
+export async function interopDefault<T>(m: PromiseLike<T> | T): Promise<T extends { default: infer U } ? U : T> {
+  const resolved = await m;
+
+  if (!!resolved && typeof resolved === "object" && "default" in resolved) {
+    return (resolved as { default: any }).default;
+  }
+
+  return resolved as any;
+}
+
+/**
+ * Import an optional peer dependency, throwing a friendly error
+ * if the module is not found (ERR_MODULE_NOT_FOUND).
+ */
+export async function importOptional<T>(modulePromise: Promise<T>, errorMessage: string): Promise<T> {
+  try {
+    return await modulePromise;
+  } catch (e: unknown) {
+    if (
+      e instanceof Error &&
+      ((e as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND" ||
+        e.message?.includes("Cannot find module") ||
+        e.message?.includes("Cannot find package"))
+    ) {
+      throw new Error(errorMessage, { cause: e });
+    }
+    throw e;
+  }
+}

--- a/tests/server/store/File.test.ts
+++ b/tests/server/store/File.test.ts
@@ -1,7 +1,5 @@
-import storage from "node-persist";
 import type { MockInstance } from "vitest";
 
-import logger from "@/server/logger";
 import FileStore from "@/server/store/File";
 import type { FileConfig } from "@/server/store/Store";
 
@@ -9,55 +7,17 @@ vi.mock("node-persist");
 vi.mock("@/server/logger");
 
 describe("FileStore constructor", () => {
-  it("should initialize with default options when opts is a string", () => {
-    const initMock = vi.fn().mockResolvedValue(true);
-    (storage.create as unknown as MockInstance).mockReturnValue({ init: initMock });
-
-    const fileStore = new FileStore("/some/dir");
-
-    expect(fileStore).not.toBeFalsy();
-
-    expect(storage.create).toHaveBeenCalledWith({
-      ttl: expect.any(Number),
-      dir: "/some/dir",
-    });
-    expect(initMock).toHaveBeenCalled();
+  it("should not throw when opts is a string", () => {
+    expect(() => new FileStore("/some/dir")).not.toThrow();
   });
 
-  it("should initialize with provided options when opts is an object", () => {
-    const initMock = vi.fn().mockResolvedValue(true);
-    (storage.create as unknown as MockInstance).mockReturnValue({ init: initMock });
-
+  it("should not throw when opts is an object", () => {
     const opts: FileConfig = {
       ttl: 1000,
       expiredInterval: 250,
       dir: "/some/dir",
     };
-    const fileStore = new FileStore(opts);
-
-    expect(fileStore).not.toBeFalsy();
-    expect(storage.create).toHaveBeenCalledWith(opts);
-    expect(initMock).toHaveBeenCalled();
-  });
-
-  it("should throw an error when init fails", () => {
-    const initMock = vi.fn().mockRejectedValue(new Error("init failed"));
-    (storage.create as unknown as MockInstance).mockReturnValue({ init: initMock });
-
-    const exitMock = vi.spyOn(process, "exit").mockImplementation(() => {
-      return undefined as never;
-    });
-
-    expect(() => new FileStore("/some/dir")).not.toThrow();
-
-    queueMicrotask(() => {
-      expect(exitMock).toHaveBeenCalledWith(1);
-
-      expect(logger.error).toHaveBeenCalledWith(
-        { message: "init failed" },
-        "Failed to initialize file store: @{message}",
-      );
-    });
+    expect(() => new FileStore(opts)).not.toThrow();
   });
 });
 
@@ -68,20 +28,37 @@ describe("FileStore methods", () => {
     getItem: MockInstance;
     removeItem: MockInstance;
   };
+  let initMock: MockInstance;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Dynamically import node-persist to get the mocked module
+    const storage = await import("node-persist");
+
     dbMock = {
       setItem: vi.fn(),
       getItem: vi.fn(),
       removeItem: vi.fn(),
     };
+    initMock = vi.fn().mockResolvedValue(true);
 
-    (storage.create as unknown as MockInstance).mockReturnValue({
-      init: vi.fn().mockResolvedValue(true),
+    (storage.default.create as unknown as MockInstance).mockReturnValue({
+      init: initMock,
       ...dbMock,
     });
 
     fileStore = new FileStore("/test/dir");
+  });
+
+  it("should initialize lazily on first operation", async () => {
+    const storage = await import("node-persist");
+
+    await fileStore.setOpenIDState("key1", "nonce1", "provider1");
+
+    expect(storage.default.create).toHaveBeenCalledWith({
+      ttl: expect.any(Number),
+      dir: "/test/dir",
+    });
+    expect(initMock).toHaveBeenCalled();
   });
 
   it("should set and get state", async () => {

--- a/tests/server/store/Redis.test.ts
+++ b/tests/server/store/Redis.test.ts
@@ -57,29 +57,32 @@ describe("RedisStore", () => {
     pipeline.exec.mockResolvedValue([]);
   });
 
-  it("should initialize redis client with default options", () => {
-    new RedisStore();
+  it("should initialize redis client with default options", async () => {
+    const store = new RedisStore();
+    await store.setOpenIDState("key", "nonce", "provider");
 
-    expect(RedisCtor).toHaveBeenCalledWith({});
+    expect(RedisCtor).toHaveBeenCalledWith();
     expect(ClusterCtor).not.toHaveBeenCalled();
   });
 
-  it("should initialize redis client with url", () => {
-    new RedisStore("redis://localhost:6379");
+  it("should initialize redis client with url", async () => {
+    const store = new RedisStore("redis://localhost:6379");
+    await store.setOpenIDState("key", "nonce", "provider");
 
-    expect(RedisCtor).toHaveBeenCalledWith("redis://localhost:6379", {});
+    expect(RedisCtor).toHaveBeenCalledWith("redis://localhost:6379");
     expect(ClusterCtor).not.toHaveBeenCalled();
   });
 
-  it("should initialize redis client with single-node options", () => {
-    new RedisStore({ host: "127.0.0.1", port: 6379, ttl: 12_345 });
+  it("should initialize redis client with single-node options", async () => {
+    const store = new RedisStore({ host: "127.0.0.1", port: 6379, ttl: 12_345 });
+    await store.setOpenIDState("key", "nonce", "provider");
 
     expect(RedisCtor).toHaveBeenCalledWith({ host: "127.0.0.1", port: 6379 });
     expect(ClusterCtor).not.toHaveBeenCalled();
   });
 
-  it("should initialize redis cluster with merged redis options", () => {
-    new RedisStore({
+  it("should initialize redis cluster with merged redis options", async () => {
+    const store = new RedisStore({
       nodes: [{ host: "127.0.0.1", port: 7000 }],
       ttl: 12_345,
       username: "user",
@@ -87,6 +90,7 @@ describe("RedisStore", () => {
       redisOptions: { db: 2 },
       scaleReads: "all",
     });
+    await store.setOpenIDState("key", "nonce", "provider");
 
     expect(ClusterCtor).toHaveBeenCalledWith([{ host: "127.0.0.1", port: 7000 }], {
       redisOptions: { username: "user", password: "pass", db: 2 },
@@ -221,6 +225,7 @@ describe("RedisStore", () => {
 
   it("should disconnect when quit fails", async () => {
     const store = new RedisStore();
+    await store.setOpenIDState("key", "nonce", "provider"); // trigger client init
 
     redisClient.quit.mockRejectedValueOnce(new Error("quit failed"));
 

--- a/tests/server/store/index.test.ts
+++ b/tests/server/store/index.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createStore } from "@/server/store";
+import { StoreType } from "@/server/store/Store";
+
+function mockConfig(storeType: StoreType, storeConfig: unknown = {}) {
+  return {
+    storeType,
+    getStoreConfig: vi.fn().mockReturnValue(storeConfig),
+  } as any;
+}
+
+describe("createStore", () => {
+  it("should return InMemoryStore for default store type", () => {
+    const config = mockConfig(StoreType.InMemory);
+    const store = createStore(config);
+
+    expect(store).toBeDefined();
+    expect(config.getStoreConfig).toHaveBeenCalledWith(StoreType.InMemory);
+  });
+
+  it("should return InMemoryStore for unknown store type", () => {
+    const config = mockConfig("unknown" as StoreType);
+    const store = createStore(config);
+
+    expect(store).toBeDefined();
+    expect(config.getStoreConfig).toHaveBeenCalledWith("unknown");
+  });
+
+  it("should return RedisStore for redis store type", () => {
+    const config = mockConfig(StoreType.Redis);
+    const store = createStore(config);
+
+    expect(store).toBeDefined();
+    expect(config.getStoreConfig).toHaveBeenCalledWith(StoreType.Redis);
+  });
+
+  it("should return FileStore for file store type", () => {
+    const config = mockConfig(StoreType.File);
+    const store = createStore(config);
+
+    expect(store).toBeDefined();
+    expect(config.getStoreConfig).toHaveBeenCalledWith(StoreType.File);
+  });
+});

--- a/tests/server/utils.test.ts
+++ b/tests/server/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { importOptional, interopDefault } from "@/server/utils";
+
+describe("importOptional", () => {
+  it("should return the module namespace on successful import", async () => {
+    vi.doMock("@/server/store/Redis", () => ({
+      default: class MockRedisStore {},
+      Cluster: class MockCluster {},
+    }));
+
+    const { importOptional } = await import("@/server/utils");
+    const result = (await importOptional(import("@/server/store/Redis"), "should not throw")) as any;
+    expect(result).toBeDefined();
+    expect(result.default).toBeDefined();
+    expect(result.Cluster).toBeDefined();
+  });
+
+  it("should throw a friendly error on ERR_MODULE_NOT_FOUND", async () => {
+    await expect(
+      // @ts-expect-error module does not exist
+      importOptional(import("./this-does-not-exist"), 'Package "foo" is required. Install it: pnpm add foo'),
+    ).rejects.toThrow('Package "foo" is required. Install it: pnpm add foo');
+  });
+});
+
+describe("interopDefault", () => {
+  it("should unwrap default export", async () => {
+    const result = await interopDefault({ default: { foo: "bar" } });
+    expect(result).toEqual({ foo: "bar" });
+  });
+
+  it("should return module as-is when no default", async () => {
+    const result = await interopDefault({ foo: "bar" });
+    expect(result).toEqual({ foo: "bar" });
+  });
+
+  it("should handle promise", async () => {
+    const result = await interopDefault(Promise.resolve({ default: { foo: "bar" } }));
+    expect(result).toEqual({ foo: "bar" });
+  });
+});


### PR DESCRIPTION
- Move ioredis and node-persist to peerDependencies with optional meta
- Add src/server/utils.ts: interopDefault + importOptional for lazy ESM/CJS interop
- RedisStore: lazy ioredis import via importOptional, exclude ttl from config type
- FileStore: lazy node-persist import via importOptional + interopDefault
- Fix close() race condition: await pending initialization before cleanup
- Reset db/redis references on close to prevent stale state reuse