### PR TITLE
fix(plugin): escape the injected login options

### DIFF
--- a/src/server/plugin/PatchHtml.ts
+++ b/src/server/plugin/PatchHtml.ts
@@ -79,9 +79,16 @@ export class PatchHtml implements PluginMiddleware {
 
     const scriptSrc = `${baseUrl}${staticPath}/${scriptName}`;
 
+    // JSON.stringify escapes quotes; replacing "<" keeps a configured
+    // "</script>" value from terminating the inline script block.
+    const options = JSON.stringify({
+      keepPasswdLogin: this.keepPasswdLogin,
+      loginButtonText: this.loginButtonText,
+    }).replaceAll("<", String.raw`\u003C`);
+
     return [
       `<script>`,
-      `    window.__VERDACCIO_OPENID_OPTIONS={"keepPasswdLogin":${this.keepPasswdLogin},"loginButtonText":"${this.loginButtonText}"}`,
+      `    window.__VERDACCIO_OPENID_OPTIONS=${options}`,
       `</script>`,
       `<script defer="defer" src="${scriptSrc}"></script>`,
       "",

--- a/tests/server/plugin/PatchHtml.test.ts
+++ b/tests/server/plugin/PatchHtml.test.ts
@@ -24,6 +24,42 @@ describe("PatchHtml", () => {
     return new PatchHtml(config);
   }
 
+  const HTML = `
+<html>
+  <head>
+    <script>window.${VERDACCIO_BASENAME_UI_OPTIONS_MARKER}={}</script>
+  </head>
+  <body>
+  </body>
+</html>`;
+
+  /** The options object as it appears in the injected inline script. */
+  function injectedOptions(loginButtonText: string): string {
+    const patcher = new PatchHtml({ ...config, loginButtonText } as any);
+    // @ts-expect-error insertTags is private
+    const result: string = patcher.insertTags(HTML, request);
+    const match = result.match(/__VERDACCIO_OPENID_OPTIONS=(\{.*?\})\s*<\/script>/);
+    expect(match, `no options object found in:\n${result}`).not.toBeNull();
+    return match![1];
+  }
+
+  it("does not let a loginButtonText terminate the inline script block", () => {
+    const options = injectedOptions(`</script><script>window.__pwned=1</script>`);
+
+    // The text survives as inert data; what must not survive is a real
+    // closing tag that ends the script and starts a new one.
+    expect(options).not.toContain("</script>");
+    expect(options).toContain(String.raw`\u003C/script>`);
+    expect(JSON.parse(options).loginButtonText).toBe(`</script><script>window.__pwned=1</script>`);
+  });
+
+  it("emits parseable JSON for a loginButtonText containing quotes", () => {
+    const options = injectedOptions('Sign "in" now');
+
+    expect(() => JSON.parse(options)).not.toThrow();
+    expect(JSON.parse(options).loginButtonText).toBe('Sign "in" now');
+  });
+
   it("should inject script tags for Verdaccio <= 6.4 HTML", () => {
     const html = `
 <html>


### PR DESCRIPTION
`loginButtonText` is interpolated straight into the inline script tag that sets `window.__VERDACCIO_OPENID_OPTIONS`:

```js
// src/server/plugin/PatchHtml.ts
`    window.__VERDACCIO_OPENID_OPTIONS={"keepPasswdLogin":${this.keepPasswdLogin},"loginButtonText":"${this.loginButtonText}"}`
```

Two ways that breaks:

- A value containing a **double quote** produces invalid JavaScript. The options object never gets defined, and the login button silently fails to render.
- A value containing **`</script>`** closes the tag early and everything after it is parsed as markup. With `loginButtonText: '</script><script>alert(1)</script>'` the injected script really does run.

The value comes from the verdaccio config rather than from a request, so this is an operator footgun rather than something an anonymous visitor can reach. Still worth closing — config is often templated from environment variables or a secret store, and a stray quote turning into a broken login page is a confusing thing to debug.

## The fix

Build the object with `JSON.stringify` (escapes quotes and control characters), then replace `<` with `<`. That escape is valid inside a JSON string and parses back to the original character, so the value the client sees is **unchanged** — it just can't terminate the script element.

Before, with a hostile value:

```html
<script>      window.__VERDACCIO_OPENID_OPTIONS={"keepPasswdLogin":true,"loginButtonText":"</script><script>window.__pwned=1</script>"}  </script>
```

After:

```html
<script>      window.__VERDACCIO_OPENID_OPTIONS={"keepPasswdLogin":true,"loginButtonText":"</script><script>window.__pwned=1</script>"}  </script>
```

## Tests

Two cases added to `tests/server/plugin/PatchHtml.test.ts`, both asserting the round-trip — the hostile value is still readable as data, it just can't close the tag:

- a `loginButtonText` of `</script><script>window.__pwned=1</script>` leaves no `</script>` inside the options object, and `JSON.parse(...).loginButtonText` returns the original string
- a `loginButtonText` of `Sign "in" now` still yields parseable JSON

Both fail against `main` and pass with the fix. Full suite: **369 passed**, `oxlint` and `oxfmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)