### PR TITLE
fix(store): guard a missing dynamo config, split read consistency

### DIFF
--- a/src/server/store/Dynamo.ts
+++ b/src/server/store/Dynamo.ts
@@ -116,10 +116,10 @@ export default class DynamoStore extends BaseStore implements Store {
   private client?: DynamoDBDocumentClient;
   private clientPromise?: Promise<DynamoDBDocumentClient>;
 
-  constructor(opts: DynamoConfig) {
+  constructor(opts?: DynamoConfig) {
     super();
 
-    if (!opts.tableName) {
+    if (!opts?.tableName) {
       throw new Error("DynamoStore: `tableName` is required");
     }
     if (!opts.region) {
@@ -196,7 +196,10 @@ export default class DynamoStore extends BaseStore implements Store {
     }
   }
 
-  private async get<T = Record<string, unknown>>(sk: string): Promise<T | undefined> {
+  /** `isConsistent` is for read-after-write paths (state, webauthn);
+   *  cache-style data (userinfo, groups) tolerates eventual reads at
+   *  half the RCU cost. */
+  private async get<T = Record<string, unknown>>(sk: string, isConsistent = false): Promise<T | undefined> {
     try {
       const client = await this.getClient();
       const { GetCommand } = await import("@aws-sdk/lib-dynamodb");
@@ -205,7 +208,7 @@ export default class DynamoStore extends BaseStore implements Store {
         new GetCommand({
           TableName: this.tableName,
           Key: { pk: this.pk, sk },
-          ConsistentRead: true,
+          ConsistentRead: isConsistent,
         }),
       );
       if (out.Item && typeof out.Item.expires === "number" && out.Item.expires * 1000 < Date.now()) {
@@ -247,7 +250,7 @@ export default class DynamoStore extends BaseStore implements Store {
   }
 
   async getOpenIDState(key: string, providerId: string): Promise<string | undefined> {
-    const item = await this.get<{ nonce?: string }>(this.getStateKey(key, providerId));
+    const item = await this.get<{ nonce?: string }>(this.getStateKey(key, providerId), true);
     return item?.nonce;
   }
 
@@ -296,7 +299,7 @@ export default class DynamoStore extends BaseStore implements Store {
   }
 
   async getWebAuthnToken(key: string): Promise<string | undefined> {
-    const item = await this.get<{ token?: string }>(this.getWebAuthnTokenKey(key));
+    const item = await this.get<{ token?: string }>(this.getWebAuthnTokenKey(key), true);
     return item?.token;
   }
 
@@ -313,7 +316,7 @@ export default class DynamoStore extends BaseStore implements Store {
    */
   async takeWebAuthnToken(key: string, pendingToken: string): Promise<string | undefined> {
     const sk = this.getWebAuthnTokenKey(key);
-    const item = await this.get<{ token?: string }>(sk);
+    const item = await this.get<{ token?: string }>(sk, true);
     const current = item?.token;
     if (current === undefined) return undefined;
     if (current === pendingToken) return current;

--- a/tests/server/store/Dynamo.test.ts
+++ b/tests/server/store/Dynamo.test.ts
@@ -54,6 +54,41 @@ describe("DynamoStore — required config", () => {
   it("throws if region is missing", () => {
     expect(() => new DynamoStore({ tableName: "x" } as any)).toThrow(/region/);
   });
+
+  it("throws a readable error when the store config block is absent", () => {
+    // Without the optional chain this is a TypeError whose message happens to
+    // contain "tableName" too, so match the real error and its type.
+    expect(() => new DynamoStore(undefined as any)).toThrow("DynamoStore: `tableName` is required");
+    expect(() => new DynamoStore(undefined as any)).not.toThrow(TypeError);
+  });
+});
+
+describe("DynamoStore — read consistency", () => {
+  // Strongly consistent reads cost twice the RCUs. Only read-after-write
+  // paths need them; cache-style rows tolerate eventual reads.
+  const readConsistencyOf = async (fn: (s: DynamoStore) => Promise<unknown>) => {
+    sendMock.mockResolvedValue({});
+    await fn(new DynamoStore(baseConfig));
+    const cmd = sendMock.mock.calls.at(-1)![0];
+    expect(cmd.__type).toBe("Get");
+    return cmd.input.ConsistentRead;
+  };
+
+  it("reads openid state strongly consistently", async () => {
+    await expect(readConsistencyOf((s) => s.getOpenIDState("session-abc", "openid"))).resolves.toBe(true);
+  });
+
+  it("reads the webauthn token strongly consistently", async () => {
+    await expect(readConsistencyOf((s) => s.getWebAuthnToken("key"))).resolves.toBe(true);
+  });
+
+  it("reads cached user info eventually consistently", async () => {
+    await expect(readConsistencyOf((s) => s.getUserInfo("user", "openid"))).resolves.toBe(false);
+  });
+
+  it("reads cached user groups eventually consistently", async () => {
+    await expect(readConsistencyOf((s) => s.getUserGroups("user", "openid"))).resolves.toBe(false);
+  });
 });
 
 describe("DynamoStore — openid state", () => {


### PR DESCRIPTION
Two small changes to the DynamoDB store, plus the tests that were missing for both. Happy to split this into two PRs if you'd prefer — they're independent.

## 1. Missing config block

`DynamoStore` takes a required `DynamoConfig` and dereferences `opts.tableName` immediately. A verdaccio config that sets `store-type: dynamodb` and forgets `store-config` fails with:

```
TypeError: Cannot read properties of undefined (reading 'tableName')
```

The constructor now accepts `undefined` and the guard uses an optional chain, so the operator gets the error the code already meant to raise: ``DynamoStore: `tableName` is required``.

## 2. Read consistency

Every read currently goes out with `ConsistentRead: true`. Strongly consistent reads cost **twice the read capacity units** and take longer, and this table is touched on every login.

Only read-after-write paths actually need them:

| path | consistency | why |
|---|---|---|
| `getOpenIDState` | strong | reads a nonce written moments earlier in the same flow |
| `getWebAuthnToken`, `takeWebAuthnToken` | strong | reads back a token the CLI flow just stored |
| `getUserInfo`, `getUserGroups` | eventual | caches — a row arriving late is refetched from the provider |

A cache row arriving a moment late costs one extra provider call. A state nonce arriving late breaks the auth flow. That's where the line is drawn.

## Tests

Both behaviours were untested — the suite asserts what the store *writes* but never `ConsistentRead`, so a change back to always-consistent would pass CI silently. Five assertions added, one per read path plus the missing-config error.

Each was mutation-checked against this branch:

- reverting `ConsistentRead: isConsistent` → `true` fails exactly the two eventual-read tests
- reverting `!opts?.tableName` → `!opts.tableName` fails the config test

That second one is worth a note: matching only `/tableName/` **passes either way**, because the `TypeError` raised without the guard also contains that word. The test matches the exact message and asserts the error is not a `TypeError`.

Full suite: **372 passed**, `oxlint` and `oxfmt --check` clean.

## Context

We run this plugin with the DynamoDB store on a multi-replica verdaccio behind Authentik. Both of these came out of that deployment. Thanks for taking the store upstream in 0.18.0 — the lazy-loading and error handling you added on top are a clear improvement over what we had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)